### PR TITLE
Switch to Manifest V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
-/archive.zip
+.DS_Store
+Thumbs.db
+/archive_chrome.zip
+/archive_firefox.zip
+/manifest.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,15 @@ The following image shows the links produced by HNDD on a duplicate HN submissio
 
 ![Screenshot](screenshots/screenshot-cropped.png)
 
+Development
+-----------
+
+A different `manifest.json` is used for Chrome and Firefox. For development, create a symbolic link
+`manifest.json` that points to either `manifest_chrome.json` or `manifest_firefox.json`, depending
+on the environment.
+
+To generate zip archives, run `zip.sh`.
+
 License
 -------
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,21 +1,22 @@
 {
    "background": {
-      "scripts": ["src/background.js"]
+      "service_worker": "src/background.js"
    },
    "content_scripts": [ {
       "js": ["src/library.js", "src/main.js"],
       "matches": [ "https://news.ycombinator.com/item?id=*" ]
    } ],
    "description": "Detects duplicate HN submissions.",
+   "host_permissions": ["https://hn.algolia.com/api/v1/search?query=*"],
    "icons": {
       "48": "icons/icon-48.png",
       "128": "icons/icon-128.png"
    },
-   "manifest_version": 2,
+   "manifest_version": 3,
    "name": "Hacker News Duplicate Detector",
    "options_ui": {
       "page": "src/options.html"
    },
-   "permissions": ["https://hn.algolia.com/api/v1/search?query=*", "storage"],
+   "permissions": ["storage"],
    "version": "1.8.2"
 }

--- a/manifest_chrome.json
+++ b/manifest_chrome.json
@@ -18,5 +18,5 @@
       "page": "src/options.html"
    },
    "permissions": ["storage"],
-   "version": "1.9.0"
+   "version": "1.10.0"
 }

--- a/manifest_firefox.json
+++ b/manifest_firefox.json
@@ -1,0 +1,21 @@
+{
+   "background": {
+      "scripts": ["src/background.js"]
+   },
+   "content_scripts": [ {
+      "js": ["src/library.js", "src/main.js"],
+      "matches": [ "https://news.ycombinator.com/item?id=*" ]
+   } ],
+   "description": "Detects duplicate HN submissions.",
+   "icons": {
+      "48": "icons/icon-48.png",
+      "128": "icons/icon-128.png"
+   },
+   "manifest_version": 2,
+   "name": "Hacker News Duplicate Detector",
+   "options_ui": {
+      "page": "src/options.html"
+   },
+   "permissions": ["https://hn.algolia.com/api/v1/search?query=*", "storage"],
+   "version": "1.10.0"
+}

--- a/src/background.js
+++ b/src/background.js
@@ -1,13 +1,8 @@
-// WARN: For functions that are called from the options page, proper scope is
-// necessary (e.g., using a function declaration beginning with a 'function',
-// or using a function expression beginning with 'var', but not a function
-// expression beginning with 'let' or 'const').
-
-function defaultOptions() {
+const defaultOptions = function() {
     const options = Object.create(null);
     options['omitZeroComments'] = true;
     return options;
-}
+};
 
 // set missing options using defaults
 (function() {
@@ -23,3 +18,10 @@ function defaultOptions() {
         chrome.storage.local.set({options: options});
     });
 })();
+
+chrome.runtime.onMessage.addListener(function(request, sender, sendResponse) {
+    const method = request.method;
+    if (method === 'getDefaultOptions') {
+        sendResponse(defaultOptions());
+    }
+});

--- a/src/options.js
+++ b/src/options.js
@@ -34,9 +34,10 @@ document.addEventListener('DOMContentLoaded', function() {
 
         // load default options
         document.getElementById('defaults').addEventListener('click', function() {
-            const defaults = chrome.extension.getBackgroundPage().defaultOptions();
-            loadOptions(defaults);
-            statusMessage('Defaults Loaded', 1200);
+            chrome.runtime.sendMessage({method: 'getDefaultOptions'}, (response) => {
+                loadOptions(response);
+                statusMessage('Defaults Loaded', 1200);
+            });
         });
 
         document.getElementById('revert').addEventListener('click', function() {

--- a/zip.sh
+++ b/zip.sh
@@ -1,21 +1,31 @@
 #!/usr/bin/env bash
 
-# run this from the package directory
+scriptdir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd "${scriptdir}"
 
-# easier to see args in an array than a string
-ARGS=()
-ARGS+=("src/")
-ARGS+=("icons/")
-ARGS+=("manifest.json")
+gen_archive() {
+  browser="${1}"
 
-# exclude
-ARGS+=("-x")
-ARGS+=("*.DS_Store")
+  # easier to see args in an array than a string
+  args=()
+  args+=("icons/")
+  args+=("src/")
+  args+=("manifest_${browser}.json")
 
-archive="archive.zip"
+  # exclude
+  args+=("-x")
+  args+=("*.DS_Store")
+  args+=("*Thumbs.db")
 
-if [ -f "${archive}" ]; then
-	rm "${archive}"
-fi
+  archive="archive_${browser}.zip"
 
-zip -r "${archive}" "${ARGS[@]}"
+  if [ -f "${archive}" ]; then
+    rm "${archive}"
+  fi
+
+  zip -r "${archive}" "${args[@]}"
+  printf "@ manifest_${browser}.json\n@=manifest.json\n" | zipnote -w "${archive}"
+}
+
+gen_archive chrome
+gen_archive firefox


### PR DESCRIPTION
This PR updates the extension to use Manifest V3.

Starting in January 2023, "the Chrome browser will no longer run Manifest V2 extensions." ([source](https://developer.chrome.com/blog/mv2-transition/))

Firefox does not currently support Manifest V3, but it is scheduled to be available soon: "we are hoping to complete enough work on this project to support developer testing in Q4 2021 and start accepting v3 submissions in early 2022." ([source](https://blog.mozilla.org/addons/2021/05/27/manifest-v3-update/))